### PR TITLE
Fixes linker error on Linux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ tape.o \
 tcbm.o \
 tedmem.o \
 tedsound.o \
+Via.o \
 vic2mem.o \
 video.o
 
@@ -124,12 +125,15 @@ tedsound.o : tedsound.cpp
 vic2mem.o : vic2mem.cpp vic2mem.h
 	$(CC) $(cflags) -c $<
 
+Via.o : Via.cpp Via.h
+	$(CC) $(cflags) -c $<
+
 video.o : video.cpp
 	$(CC) $(cflags) -c $<
 
 clean :
 	rm -f ./*.o
-	rm ./$(EXENAME)
+	rm -f ./$(EXENAME)
 
 tgz :
 	tar -czf $(SRCPACKAGENAME).tar.gz $(sourcefiles) Makefile COPYING README.SDL Changes


### PR DESCRIPTION
Hi 
thanks for running this project.

I noticed a small issue that prevents the linker to build the binary when running `make` on Linux (Debian Bookworm, 64Bit).

This PR is my proposed fix.